### PR TITLE
fix unsupported filter in ansible 2.9

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -27,7 +27,7 @@ es_data_dirs: "/var/lib/elasticsearch"
 es_log_dir: "/var/log/elasticsearch"
 es_action_auto_create_index: true
 es_max_open_files: 65536
-es_max_threads: "{{ 2048 if ( es_version | version_compare('6.0.0', '<')) else 8192 }}"
+es_max_threads: "{{ 2048 if ( es_version is version_compare('6.0.0', '<')) else 8192 }}"
 es_max_map_count: 262144
 es_allow_downgrades: false
 es_xpack_features: ["alerting","monitoring","graph","ml","security"]

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -18,7 +18,7 @@
 - name: Detect if es_version is before X-Pack was open and included
   set_fact:
     es_open_xpack: false
-  when: "es_version in version_compare('6.3.0', '<')"
+  when: "es_version is version_compare('6.3.0', '<')"
 
 - name: If this is an older version we need to install X-Pack as a plugin and use a differet users command
   set_fact:

--- a/tasks/compatibility-variables.yml
+++ b/tasks/compatibility-variables.yml
@@ -18,14 +18,14 @@
 - name: Detect if es_version is before X-Pack was open and included
   set_fact:
     es_open_xpack: false
-  when: "es_version | version_compare('6.3.0', '<')"
+  when: "es_version in version_compare('6.3.0', '<')"
 
 - name: If this is an older version we need to install X-Pack as a plugin and use a differet users command
   set_fact:
     es_install_xpack: true
     es_xpack_users_command: "x-pack/users"
     es_xpack_conf_subdir: "/x-pack"
-  when: 
+  when:
     - not es_open_xpack
     - es_enable_xpack
 

--- a/tasks/elasticsearch-parameters.yml
+++ b/tasks/elasticsearch-parameters.yml
@@ -58,7 +58,7 @@
 #Relies on elasticsearch distribution installing a serviced script to determine whether one should be copied.
 
 - name: set fact use_system_d
-  set_fact: use_system_d={{(ansible_distribution == 'Debian' and ansible_distribution_version | version_compare('8', '>=')) or (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version | version_compare('7', '>=')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_version | version_compare('15', '>=')) }}
+  set_fact: use_system_d={{(ansible_distribution == 'Debian' and ansible_distribution_version is version_compare('8', '>=')) or (ansible_distribution in ['RedHat','CentOS'] and ansible_distribution_version is version_compare('7', '>=')) or (ansible_distribution == 'Ubuntu' and ansible_distribution_version is version_compare('15', '>=')) }}
 
 - name: set fact instance_sysd_script
   set_fact: instance_sysd_script={{sysd_script | dirname }}/{{es_instance_name}}_{{sysd_script | basename}}

--- a/tasks/xpack/elasticsearch-xpack.yml
+++ b/tasks/xpack/elasticsearch-xpack.yml
@@ -20,4 +20,4 @@
 - name: Set elasticsearch.keystore Permissions
   become: yes
   file: state=file path={{ conf_dir }}/elasticsearch.keystore owner={{ es_user }} group={{ es_group }}
-  when: es_enable_xpack and "security" in es_xpack_features and (es_version | version_compare('6.0.0', '>'))
+  when: es_enable_xpack and "security" in es_xpack_features and (es_version is version_compare('6.0.0', '>'))

--- a/tasks/xpack/security/elasticsearch-security.yml
+++ b/tasks/xpack/security/elasticsearch-security.yml
@@ -14,7 +14,7 @@
 #-----------------------------Create Bootstrap User-----------------------------------
 ### START BLOCK elasticsearch keystore ###
 - name: create the elasticsearch keystore
-  when: (es_enable_xpack and "security" in es_xpack_features) and (es_version | version_compare('6.0.0', '>'))
+  when: (es_enable_xpack and "security" in es_xpack_features) and (es_version is version_compare('6.0.0', '>'))
   block:
   - name: create the keystore if it doesn't exist yet
     become: yes

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -15,7 +15,7 @@ node.name: {{inventory_hostname}}-{{es_instance_name}}
 
 # Path to directory containing configuration (this file and logging.yml):
 
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 path.conf: {{ conf_dir }}
 {% endif %}
 
@@ -71,5 +71,5 @@ xpack.notification.email:
         {% if es_mail_config['require_auth'] == true %}
         user: {{ es_mail_config['user'] }}
         password: {{ es_mail_config['pass'] }}
-        {% endif %}  
+        {% endif %}
 {% endif %}

--- a/templates/init/debian/elasticsearch.j2
+++ b/templates/init/debian/elasticsearch.j2
@@ -92,7 +92,7 @@ fi
 # Define other required variables
 PID_FILE="$PID_DIR/$NAME.pid"
 DAEMON=$ES_HOME/bin/elasticsearch
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 DAEMON_OPTS="-d -p $PID_FILE -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR"
 {% else %}
 DAEMON_OPTS="-d -p $PID_FILE"

--- a/templates/init/redhat/elasticsearch.j2
+++ b/templates/init/redhat/elasticsearch.j2
@@ -140,7 +140,7 @@ start() {
     cd $ES_HOME
     echo -n $"Starting $prog: "
     # if not running, start it up here, usually something like "daemon $exec"
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
     daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d -Edefault.path.logs=$LOG_DIR -Edefault.path.data=$DATA_DIR -Edefault.path.conf=$CONF_DIR
 {% else %}
     daemon --user $ES_USER --pidfile $pidfile $exec -p $pidfile -d

--- a/templates/log4j2.properties.j2
+++ b/templates/log4j2.properties.j2
@@ -11,14 +11,14 @@ appender.console.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%m%n
 
 appender.rolling.type = RollingFile
 appender.rolling.name = rolling
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.rolling.fileName = ${sys:es.logs}.log
 {% else %}
 appender.rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}.log
 {% endif %}
 appender.rolling.layout.type = PatternLayout
 appender.rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.rolling.filePattern = ${sys:es.logs}-%d{yyyy-MM-dd}.log
 {% else %}
 appender.rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}-%d{yyyy-MM-dd}-%i.log.gz
@@ -27,7 +27,7 @@ appender.rolling.policies.type = Policies
 appender.rolling.policies.time.type = TimeBasedTriggeringPolicy
 appender.rolling.policies.time.interval = 1
 appender.rolling.policies.time.modulate = true
-{% if (es_version | version_compare('6.0.0', '>')) %}
+{% if (es_version is version_compare('6.0.0', '>')) %}
 appender.rolling.policies.size.type = SizeBasedTriggeringPolicy
 appender.rolling.policies.size.size = 128MB
 appender.rolling.strategy.type = DefaultRolloverStrategy
@@ -45,14 +45,14 @@ rootLogger.appenderRef.rolling.ref = rolling
 
 appender.deprecation_rolling.type = RollingFile
 appender.deprecation_rolling.name = deprecation_rolling
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.deprecation_rolling.fileName = ${sys:es.logs}_deprecation.log
 {% else %}
 appender.deprecation_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation.log
 {% endif %}
 appender.deprecation_rolling.layout.type = PatternLayout
 appender.deprecation_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c{1.}] %marker%.-10000m%n
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.deprecation_rolling.filePattern = ${sys:es.logs}_deprecation-%i.log.gz
 {% else %}
 appender.deprecation_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_deprecation-%i.log.gz
@@ -70,14 +70,14 @@ logger.deprecation.additivity = false
 
 appender.index_search_slowlog_rolling.type = RollingFile
 appender.index_search_slowlog_rolling.name = index_search_slowlog_rolling
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.index_search_slowlog_rolling.fileName = ${sys:es.logs}_index_search_slowlog.log
 {% else %}
 appender.index_search_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog.log
 {% endif %}
 appender.index_search_slowlog_rolling.layout.type = PatternLayout
 appender.index_search_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs}_index_search_slowlog-%d{yyyy-MM-dd}.log
 {% else %}
 appender.index_search_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_search_slowlog-%d{yyyy-MM-dd}.log
@@ -94,14 +94,14 @@ logger.index_search_slowlog_rolling.additivity = false
 
 appender.index_indexing_slowlog_rolling.type = RollingFile
 appender.index_indexing_slowlog_rolling.name = index_indexing_slowlog_rolling
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs}_index_indexing_slowlog.log
 {% else %}
 appender.index_indexing_slowlog_rolling.fileName = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog.log
 {% endif %}
 appender.index_indexing_slowlog_rolling.layout.type = PatternLayout
 appender.index_indexing_slowlog_rolling.layout.pattern = [%d{ISO8601}][%-5p][%-25c] %marker%.-10000m%n
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs}_index_indexing_slowlog-%d{yyyy-MM-dd}.log
 {% else %}
 appender.index_indexing_slowlog_rolling.filePattern = ${sys:es.logs.base_path}${sys:file.separator}${sys:es.logs.cluster_name}_index_indexing_slowlog-%d{yyyy-MM-dd}.log

--- a/templates/systemd/elasticsearch.j2
+++ b/templates/systemd/elasticsearch.j2
@@ -18,13 +18,13 @@ WorkingDirectory={{es_home}}
 User={{es_user}}
 Group={{es_group}}
 
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
 ExecStartPre=/usr/share/elasticsearch/bin/elasticsearch-systemd-pre-exec
 {% endif %}
 
 ExecStart={{es_home}}/bin/elasticsearch \
                                     -p ${PID_DIR}/elasticsearch.pid \
-{% if (es_version | version_compare('6.0.0', '<')) %}
+{% if (es_version is version_compare('6.0.0', '<')) %}
                                     -Edefault.path.logs=${LOG_DIR} \
                                     -Edefault.path.data=${DATA_DIR} \
                                     -Edefault.path.conf=${CONF_DIR} \


### PR DESCRIPTION
filter `version_compare` was deprecated in 2.5 and removed in 2.9